### PR TITLE
Removed unnecessary separator next to the refresh button

### DIFF
--- a/src/main/java/scadinspect/gui/BottomArea.java
+++ b/src/main/java/scadinspect/gui/BottomArea.java
@@ -29,7 +29,6 @@ public class BottomArea extends ToolBar{
 
     //initialize SeparatorPane to align Buttons
     private Pane separatorPane = new Pane();
-    private Separator separator = new Separator();
 
     private ImageView loadIcon(String fileName) {
         InputStream inputStream = Main.class.getResourceAsStream(Main.RESOURCES_DIR + fileName + ".png");
@@ -70,7 +69,6 @@ public class BottomArea extends ToolBar{
         HBox.setHgrow(separatorPane, Priority.ALWAYS);
         //adding all buttons
         this.getItems().add(refreshButton);
-        this.getItems().add(separator);
         this.getItems().add(separatorPane);
         this.getItems().add(exportButton);
         this.getItems().add(closeProjectButton);
@@ -82,7 +80,6 @@ public class BottomArea extends ToolBar{
         switch (button){
             case 0: {
                 refreshButton.setVisible(false);
-                separator.setVisible(false);
                 exportButton.setVisible(false);
                 closeProjectButton.setVisible(false);
 


### PR DESCRIPTION
closes #166 

The additional space is needed for the progress bar.